### PR TITLE
Glitch file directly

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -1,0 +1,34 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.9', '1', 'nightly']
+        julia-arch: 
+          - x64
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        # with:
+        #   annotate: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,23 @@
 name = "JpegGlitcher"
 uuid = "7e1ea31b-b9a5-4cc0-940e-7c5f7cd080d6"
-authors = ["Théo Galy-Fajou <theo.galyfajou@gmail.com> and contributors"]
-version = "1.0.0"
+authors = [
+    "JuliaWTF, Théo Galy-Fajou <theo.galyfajou@gmail.com> and contributors",
+]
+version = "1.1.0"
 
 [deps]
 JpegTurbo = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[weakdeps]
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+
+[extensions]
+JpegGlitcherImageIOExt = ["ImageIO", "FileIO"]
+
 [compat]
-julia = "1.6"
+FileIO = "1"
+ImageIO = "0.6"
 JpegTurbo = "0.1"
+julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here is a basic example, using the default parameters.
 
 ```julia
 using JpegGlitcher
-using Random, FileIO, TestImages
+using RandomFileIO, TestImages
 
 img = testimage("mountainview")
 glitch(img)
@@ -25,3 +25,15 @@ cat([glitch(img; rng = Random.Xoshiro(42), n = i, quality = 20) for i in 1:50]..
 ```
 
 ![Low quality animated glitching](assets/glitched_anim.gif)
+
+## Glitch file
+
+You can also directly glitch a file by loading `FileIO.jl` and `ImageIO.jl`.
+
+```julia
+using JpegGlitcher, FileIO, ImageIO
+
+glitch("my_beautiful_img.png", "my_glitched_img.png")
+```
+
+The glitching will work on any image format supported by `ImageIO`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is a basic example, using the default parameters.
 using JpegGlitcher
 using RandomFileIO, TestImages
 
-img = testimage("mountainview")
+img = testimage("mountainstream")
 glitch(img)
 ```
 

--- a/ext/JpegGlitcherImageIOExt.jl
+++ b/ext/JpegGlitcherImageIOExt.jl
@@ -6,14 +6,15 @@ using JpegGlitcher
 using Random: AbstractRNG, default_rng
 
 """
-    glitch(file_in::AbstractString, file_out::AbstractString; rng::AbstractRNG=default_rng(), nflips::Integer=10, quality::Integer=100)
+    glitch(file_in::AbstractString, file_out::AbstractString = auto_glitch_name(file_in); rng::AbstractRNG=default_rng(), nflips::Integer=10, quality::Integer=100)
 
 Glitch image from `file_in` and write the output in `file_out`.
 See other method signature for keyword usage.
+    
 """
 function JpegGlitcher.glitch(
     file_in::AbstractString,
-    file_out::AbstractString;
+    file_out::AbstractString=auto_glitch_name(file_in);
     rng::AbstractRNG=default_rng(),
     n::Integer=10,
     quality::Integer=100,
@@ -21,6 +22,12 @@ function JpegGlitcher.glitch(
     img = FileIO.load(file_in)
     glitched_img = glitch(img; rng, n, quality)
     FileIO.save(file_out, glitched_img)
+end
+
+"Automatically append `_glitched` to the original file name."
+function auto_glitch_name(path::String)
+    path, ext = splitext(path)
+    string(path, "_glitched", ext)
 end
 
 end

--- a/ext/JpegGlitcherImageIOExt.jl
+++ b/ext/JpegGlitcherImageIOExt.jl
@@ -1,0 +1,26 @@
+module JpegGlitcherImageIOExt
+
+using ImageIO
+using FileIO
+using JpegGlitcher
+using Random: AbstractRNG, default_rng
+
+"""
+    glitch(file_in::AbstractString, file_out::AbstractString; rng::AbstractRNG=default_rng(), nflips::Integer=10, quality::Integer=100)
+
+Glitch image from `file_in` and write the output in `file_out`.
+See other method signature for keyword usage.
+"""
+function JpegGlitcher.glitch(
+    file_in::AbstractString,
+    file_out::AbstractString;
+    rng::AbstractRNG=default_rng(),
+    n::Integer=10,
+    quality::Integer=100,
+)
+    img = FileIO.load(file_in)
+    glitched_img = glitch(img; rng, n, quality)
+    FileIO.save(file_out, glitched_img)
+end
+
+end

--- a/src/JpegGlitcher.jl
+++ b/src/JpegGlitcher.jl
@@ -70,10 +70,4 @@ function glitch(
     jpeg_decode(data)
 end
 
-function glitch_append(path::AbstractString)
-    split_path()
-
-end
-
-
 end

--- a/src/JpegGlitcher.jl
+++ b/src/JpegGlitcher.jl
@@ -17,7 +17,7 @@ Within the entropy-coded data, after any 0xFF byte, a 0x00 byte is inserted by t
 =#
 
 """
-    glitch(img; rng::AbstractRNG=default_rng(), nflips::Integer=10, quality::Integer=100)
+    glitch(img::AbstractMatrix; rng::AbstractRNG=default_rng(), nflips::Integer=10, quality::Integer=100)
 
 `glitch` will turn an image into a compressed JPEG format with JPEGTurbo.jl and
 randomly change some bytes (safe to change) of the encoded image.
@@ -29,10 +29,10 @@ randomly change some bytes (safe to change) of the encoded image.
 - `quality::Integer`: the encoding quality of the JPEG (lower gives worse quality).
 """
 function glitch(
-    img;
-    rng::AbstractRNG = default_rng(),
-    n::Integer = 10,
-    quality::Integer = 100,
+    img::AbstractMatrix;
+    rng::AbstractRNG=default_rng(),
+    n::Integer=10,
+    quality::Integer=100,
 )
     0 < quality <= 100 || error("quality should be between 1 and 100.")
     n > 0 || error("number `n` should be positive.")
@@ -53,7 +53,7 @@ function glitch(
             elseif data[i] ∈ WITH_VARSIZE # The next two bytes indicate the size
                 # of the data contained by the marker.
                 high_byte, low_byte = data[i+1:i+2]
-                size = parse(UInt16, bitstring(high_byte) * bitstring(low_byte); base = 2)
+                size = parse(UInt16, bitstring(high_byte) * bitstring(low_byte); base=2)
                 i += size
             end
         else
@@ -69,5 +69,11 @@ function glitch(
     # Finally disencode the data.
     jpeg_decode(data)
 end
+
+function glitch_append(path::AbstractString)
+    split_path()
+
+end
+
 
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,8 @@
 [deps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
+
+[compat]
+FileIO = "1"
+ImageIO = "0.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using JpegGlitcher
 using Random: Xoshiro
 using Test
 using TestImages
+using ImageIO, FileIO
 
 @testset "JpegGlitcher.jl" begin
     # Test Gray images
@@ -9,17 +10,25 @@ using TestImages
         @testset "$img_name" begin
             img = testimage(img_name)
             # test alg runs fine
-            for kw in ((;), (; quality = 10), (; n = 100))
+            for kw in ((;), (; quality=10), (; n=100))
                 glitched = glitch(img)
                 @test size(img) == size(glitched)
                 @test eltype(img) == eltype(glitched)
             end
             # test rng consistency
-            @test glitch(img; rng = Xoshiro(42)) == glitch(img; rng = Xoshiro(42))
+            @test glitch(img; rng=Xoshiro(42)) == glitch(img; rng=Xoshiro(42))
             # test errors
-            @test_throws ErrorException glitch(img; quality = -1)
-            @test_throws ErrorException glitch(img; quality = 101)
-            @test_throws ErrorException glitch(img; n = -2)
+            @test_throws ErrorException glitch(img; quality=-1)
+            @test_throws ErrorException glitch(img; quality=101)
+            @test_throws ErrorException glitch(img; n=-2)
         end
+    end
+    @testset "Image in and out" begin
+        assets = joinpath(pkgdir(JpegGlitcher), "assets")
+        file_in = joinpath(assets, "glitched.png")
+        file_out = joinpath(pkgdir(JpegGlitcher), "test", "test_out.png")
+        glitch(file_in, file_out)
+        @test isfile(file_out)
+        @test load(file_out) isa Matrix{<:RGB}
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using ImageIO, FileIO
 
 @testset "JpegGlitcher.jl" begin
     # Test Gray images
-    for img_name in ("cameraman", "mountainview")
+    for img_name in ("cameraman", "mountainstream")
         @testset "$img_name" begin
             img = testimage(img_name)
             # test alg runs fine

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,17 @@ using ImageIO, FileIO
         assets = joinpath(pkgdir(JpegGlitcher), "assets")
         file_in = joinpath(assets, "glitched.png")
         file_out = joinpath(pkgdir(JpegGlitcher), "test", "test_out.png")
-        glitch(file_in, file_out)
-        @test isfile(file_out)
-        @test load(file_out) isa Matrix{<:RGB}
+        file_out_auto = joinpath(assets, "glitched_glitched.png")
+        try
+            glitch(file_in, file_out)
+            @test isfile(file_out)
+            @test load(file_out) isa Matrix
+            glitch(file_in)
+            @test isfile(file_out_auto)
+            @test load(file_out_auto) isa Matrix
+        finally
+            isfile(file_out) && rm(file_out)
+            isfile(file_out_auto) && rm(file_out_auto)
+        end
     end
 end


### PR DESCRIPTION
This add the method `glitch(file)`, and `glitch(file, file_out)` to directly glitch any image.